### PR TITLE
Moved Convex server client to SvelteKit server hooks

### DIFF
--- a/convex.json
+++ b/convex.json
@@ -1,3 +1,3 @@
 {
-	"functions": "src/convex/"
+  "functions": "src/convex/"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "convex-svelte",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "convex-svelte",
-			"version": "0.0.8",
+			"version": "0.0.9",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^3.0.0",

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -3,7 +3,9 @@
 declare global {
 	namespace App {
 		// interface Error {}
-		// interface Locals {}
+		interface Locals {
+			convex: ConvexHttpClient;
+		}
 		// interface PageData {}
 		// interface PageState {}
 		// interface Platform {}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,8 @@
+import { PUBLIC_CONVEX_URL } from '$env/static/public';
+import type { Handle } from '@sveltejs/kit';
+import { ConvexHttpClient } from 'convex/browser';
+
+export const handle: Handle = async ({ event, resolve }) => {
+	event.locals.convex = new ConvexHttpClient(PUBLIC_CONVEX_URL);
+	return resolve(event);
+};

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,11 +1,8 @@
-import { ConvexHttpClient } from 'convex/browser';
-import type { PageServerLoad } from './$types.js';
-import { PUBLIC_CONVEX_URL } from '$env/static/public';
 import { api } from '../convex/_generated/api.js';
+import type { PageServerLoad } from './$types.js';
 
-export const load = (async () => {
-	const client = new ConvexHttpClient(PUBLIC_CONVEX_URL!);
+export const load = (async ({ locals: { convex } }) => {
 	return {
-		messages: await client.query(api.messages.list, { muteWords: [] })
+		messages: await convex.query(api.messages.list, { muteWords: [] })
 	};
 }) satisfies PageServerLoad;


### PR DESCRIPTION
<!-- Describe your PR here. -->
I moved the initialization of the Convex server client to hooks.server.ts. The client is now available on any server-side page.


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
