### PR TITLE
feat: make args parameter optional in useQuery by providing default empty object

### DIFF
--- a/src/lib/client.svelte.ts
+++ b/src/lib/client.svelte.ts
@@ -60,7 +60,7 @@ type UseQueryReturn<Query extends FunctionReference<'query'>> =
  */
 export function useQuery<Query extends FunctionReference<'query'>>(
 	query: Query,
-	args: FunctionArgs<Query> | (() => FunctionArgs<Query>),
+	args: FunctionArgs<Query> | (() => FunctionArgs<Query>) = {},
 	options: UseQueryOptions<Query> | (() => UseQueryOptions<Query>) = {}
 ): UseQueryReturn<Query> {
 	const client = useConvexClient();

--- a/src/routes/inputs/Inputs.svelte
+++ b/src/routes/inputs/Inputs.svelte
@@ -4,7 +4,7 @@
 	import { api } from '../../convex/_generated/api.js';
 
 	const convex = useConvexClient();
-	const serverNumbers = useQuery(api.numbers.get, {});
+	const serverNumbers = useQuery(api.numbers.get);
 
 	let numbers = $state(null);
 	// Have some changes not yet been sent?

--- a/src/routes/tests/always-errors/+page.svelte
+++ b/src/routes/tests/always-errors/+page.svelte
@@ -3,7 +3,7 @@
 	import type { Doc } from '../../../convex/_generated/dataModel.js';
 	import { api } from '../../../convex/_generated/api.js';
 
-	const foo = useQuery(api.messages.error, {});
+	const foo = useQuery(api.messages.error);
 
 	function fail(msg: any) {
 		setTimeout(() => {


### PR DESCRIPTION
This PR brings the API of `useQuery` into parity with `useQuery` and `fetchQuery` from React and Next.js by making the `args` parameter optional in `useQuery`.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
