### PR TITLE
update README: use `onevent` syntax rather than `on:event`

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ const client = useConvexClient();
 let toSend = $state('');
 let author = $state('me');
 
-function onSubmit(e: SubmitEvent) {
+function onsubmit(e: SubmitEvent) {
+	e.preventDefault();
 	const data = Object.fromEntries(new FormData(e.target as HTMLFormElement).entries());
 	client.mutation(api.messages.send, {
 		author: data.author as string,
@@ -82,7 +83,7 @@ function onSubmit(e: SubmitEvent) {
 }
 </script>
 
-<form on:submit|preventDefault={onSubmit}>
+<form {onsubmit}>
 	<input type="text" id="author" name="author" />
 	<input type="text" id="body" name="body" bind:value={toSend} />
 	<button type="submit" disabled={!toSend}>Send</button>


### PR DESCRIPTION
<!-- Describe your PR here. -->

From svelte 5, svelte uses `onevent` syntax. Therefore I updated the example from old `on:event` to not confuse the users.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
