### PR TITLE
feat: Return client from setupConvex

### DIFF
--- a/src/lib/client.svelte.ts
+++ b/src/lib/client.svelte.ts
@@ -21,19 +21,19 @@ export const useConvexClient = (): ConvexClient => {
 	return client;
 };
 
-export const setConvexClientContext = (client: ConvexClient): void => {
-	setContext(_contextKey, client);
+export const setConvexClientContext = (client: ConvexClient): ConvexClient => {
+	return setContext(_contextKey, client);
 };
 
-export const setupConvex = (url: string, options: ConvexClientOptions = {}) => {
+export const setupConvex = (url: string, options: ConvexClientOptions = {}): ConvexClient => {
 	if (!url || typeof url !== 'string') {
 		throw new Error('Expected string url property for setupConvex');
 	}
 	const optionsWithDefaults = { disabled: !BROWSER, ...options };
 
-	const client = new ConvexClient(url, optionsWithDefaults);
-	setConvexClientContext(client);
+	const client = setConvexClientContext(new ConvexClient(url, optionsWithDefaults));
 	$effect(() => () => client.close());
+	return client;
 };
 
 // Internal sentinel for "skip" so we don't pass the literal string through everywhere


### PR DESCRIPTION
It makes more sense to return the client here since it's the default behavior of setContext. It also allows you to configure the client at the top level once instantiated. 

For example:
```svelte
<script lang="ts">
	const client = setupConvex(URL);
	client.setAuth(...)
</script>
```
