### PR TITLE
Fix: Add PUBLIC_CONVEX_URL to action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Build
         run: pnpm build
+        env:
+          PUBLIC_CONVEX_URL: ${{ vars.PUBLIC_CONVEX_URL }}
 
       - name: Lint package
         run: pnpm lint:package
@@ -45,9 +47,13 @@ jobs:
 
       - name: Test
         run: pnpm test
+        env:
+          PUBLIC_CONVEX_URL: ${{ vars.PUBLIC_CONVEX_URL }}
 
       - name: Check
         run: pnpm check
+        env:
+          PUBLIC_CONVEX_URL: ${{ vars.PUBLIC_CONVEX_URL }}
 
       - name: Lint
         run: pnpm lint

--- a/.github/workflows/preview-publish-pr.yml
+++ b/.github/workflows/preview-publish-pr.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Build
         run: pnpm build
+        env:
+          PUBLIC_CONVEX_URL: ${{ vars.PUBLIC_CONVEX_URL }}
 
       - name: Publish package preview
         run: pnpm dlx pkg-pr-new publish --template '.'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,3 +49,4 @@ jobs:
           commit: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLIC_CONVEX_URL: ${{ vars.PUBLIC_CONVEX_URL }}


### PR DESCRIPTION
Added the PUBLIC_CONVEX_URL as env variable to Github Actions so the Test and lint workflow is working.